### PR TITLE
Fix/add claims assignation on Token generation

### DIFF
--- a/NuGet/ChustaSoft.Tools.Authorization.AspNet/ChustaSoft.Tools.Authorization.AspNet.csproj
+++ b/NuGet/ChustaSoft.Tools.Authorization.AspNet/ChustaSoft.Tools.Authorization.AspNet.csproj
@@ -5,9 +5,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <PackageId>ChustaSoft.Tools.Authorization.AspNet</PackageId>
     <RootNamespace>ChustaSoft.Tools.Authorization</RootNamespace>
-    <Version>3.1.0-alpha.1</Version>
+    <Version>3.1.0</Version>
     <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>3.0.0</FileVersion>
+    <FileVersion>3.1.0-alpha.1</FileVersion>
     <Description>ASPNET layer for configuration and Embedded Controllers for ChustaSoft.Tools.Authorization project</Description>
     <Copyright>ChustaSoft</Copyright>
     <PackageLicenseUrl>https://github.com/ChustaSoft/Authorization/blob/master/LICENSE</PackageLicenseUrl>

--- a/NuGet/ChustaSoft.Tools.Authorization.AspNet/ChustaSoft.Tools.Authorization.AspNet.csproj
+++ b/NuGet/ChustaSoft.Tools.Authorization.AspNet/ChustaSoft.Tools.Authorization.AspNet.csproj
@@ -6,8 +6,8 @@
     <PackageId>ChustaSoft.Tools.Authorization.AspNet</PackageId>
     <RootNamespace>ChustaSoft.Tools.Authorization</RootNamespace>
     <Version>3.1.0-alpha.1</Version>
-    <AssemblyVersion>3.1.0-alpha.1</AssemblyVersion>
-    <FileVersion>3.1.0-alpha.1</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
     <Description>ASPNET layer for configuration and Embedded Controllers for ChustaSoft.Tools.Authorization project</Description>
     <Copyright>ChustaSoft</Copyright>
     <PackageLicenseUrl>https://github.com/ChustaSoft/Authorization/blob/master/LICENSE</PackageLicenseUrl>

--- a/NuGet/ChustaSoft.Tools.Authorization.AspNet/ChustaSoft.Tools.Authorization.AspNet.csproj
+++ b/NuGet/ChustaSoft.Tools.Authorization.AspNet/ChustaSoft.Tools.Authorization.AspNet.csproj
@@ -5,9 +5,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <PackageId>ChustaSoft.Tools.Authorization.AspNet</PackageId>
     <RootNamespace>ChustaSoft.Tools.Authorization</RootNamespace>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>3.0.0</FileVersion>
+    <Version>3.1.0-alpha.1</Version>
+    <AssemblyVersion>3.1.0-alpha.1</AssemblyVersion>
+    <FileVersion>3.1.0-alpha.1</FileVersion>
     <Description>ASPNET layer for configuration and Embedded Controllers for ChustaSoft.Tools.Authorization project</Description>
     <Copyright>ChustaSoft</Copyright>
     <PackageLicenseUrl>https://github.com/ChustaSoft/Authorization/blob/master/LICENSE</PackageLicenseUrl>

--- a/NuGet/ChustaSoft.Tools.Authorization/ChustaSoft.Tools.Authorization.csproj
+++ b/NuGet/ChustaSoft.Tools.Authorization/ChustaSoft.Tools.Authorization.csproj
@@ -6,8 +6,8 @@
     <PackageId>ChustaSoft.Tools.Authorization</PackageId>
     <RootNamespace>ChustaSoft.Tools.Authorization</RootNamespace>
     <Version>3.1.0-alpha.1</Version>
-    <AssemblyVersion>3.1.0-alpha.1</AssemblyVersion>
-    <FileVersion>3.1.0-alpha.1</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
     <Description>Authorization NuGet solution based on Microsoft Identity and JWT</Description>
     <Copyright>ChustaSoft</Copyright>
     <PackageLicenseUrl>https://github.com/ChustaSoft/Authorization/blob/master/LICENSE</PackageLicenseUrl>

--- a/NuGet/ChustaSoft.Tools.Authorization/ChustaSoft.Tools.Authorization.csproj
+++ b/NuGet/ChustaSoft.Tools.Authorization/ChustaSoft.Tools.Authorization.csproj
@@ -5,7 +5,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <PackageId>ChustaSoft.Tools.Authorization</PackageId>
     <RootNamespace>ChustaSoft.Tools.Authorization</RootNamespace>
-    <Version>3.1.0-alpha.1</Version>
+    <Version>3.1.0</Version>
     <AssemblyVersion>3.0.0</AssemblyVersion>
     <FileVersion>3.0.0</FileVersion>
     <Description>Authorization NuGet solution based on Microsoft Identity and JWT</Description>

--- a/NuGet/ChustaSoft.Tools.Authorization/ChustaSoft.Tools.Authorization.csproj
+++ b/NuGet/ChustaSoft.Tools.Authorization/ChustaSoft.Tools.Authorization.csproj
@@ -5,9 +5,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <PackageId>ChustaSoft.Tools.Authorization</PackageId>
     <RootNamespace>ChustaSoft.Tools.Authorization</RootNamespace>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0</AssemblyVersion>
-    <FileVersion>3.0.0</FileVersion>
+    <Version>3.1.0-alpha.1</Version>
+    <AssemblyVersion>3.1.0-alpha.1</AssemblyVersion>
+    <FileVersion>3.1.0-alpha.1</FileVersion>
     <Description>Authorization NuGet solution based on Microsoft Identity and JWT</Description>
     <Copyright>ChustaSoft</Copyright>
     <PackageLicenseUrl>https://github.com/ChustaSoft/Authorization/blob/master/LICENSE</PackageLicenseUrl>

--- a/NuGet/ChustaSoft.Tools.Authorization/Helpers/TokenHelper.cs
+++ b/NuGet/ChustaSoft.Tools.Authorization/Helpers/TokenHelper.cs
@@ -46,7 +46,7 @@ namespace ChustaSoft.Tools.Authorization
 
         private SecurityTokenDescriptor GenerateTokenDescriptor(User user, string privateKey)
         {
-            var claim = new[] { new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()), new Claim(ClaimTypes.Name, user.UserName), new Claim(ClaimTypes.Email, user.Email) };
+            var claims = new[] { new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()), new Claim(ClaimTypes.Name, user.UserName), new Claim(ClaimTypes.Email, user.Email) };
             var signingKey = SecurityKeyHelper.GetSecurityKey(privateKey);
             var expiringDate = DateTime.UtcNow.AddMinutes(_authorizationSettings.MinutesToExpire);
             var signingCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
@@ -55,7 +55,7 @@ namespace ChustaSoft.Tools.Authorization
             {
                 Issuer = _authorizationSettings.SiteName,
                 Audience = _authorizationSettings.SiteName,
-                Subject = new ClaimsIdentity(claim),
+                Subject = new ClaimsIdentity(claims),
                 Expires = expiringDate,
                 SigningCredentials = signingCredentials
             };

--- a/NuGet/ChustaSoft.Tools.Authorization/Helpers/TokenHelper.cs
+++ b/NuGet/ChustaSoft.Tools.Authorization/Helpers/TokenHelper.cs
@@ -1,5 +1,4 @@
 ﻿using ChustaSoft.Tools.Authorization.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using System;
 using System.IdentityModel.Tokens.Jwt;
@@ -47,7 +46,7 @@ namespace ChustaSoft.Tools.Authorization
 
         private SecurityTokenDescriptor GenerateTokenDescriptor(User user, string privateKey)
         {
-            var claim = new[] { new Claim(JwtRegisteredClaimNames.Sub, user.UserName) };
+            var claim = new[] { new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()), new Claim(ClaimTypes.Name, user.UserName), new Claim(ClaimTypes.Email, user.Email) };
             var signingKey = SecurityKeyHelper.GetSecurityKey(privateKey);
             var expiringDate = DateTime.UtcNow.AddMinutes(_authorizationSettings.MinutesToExpire);
             var signingCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
@@ -68,7 +67,7 @@ namespace ChustaSoft.Tools.Authorization
 
 
 
-    public class TokenHelper : TokenHelper<User>, ITokenHelper 
+    public class TokenHelper : TokenHelper<User>, ITokenHelper
     {
 
         public TokenHelper(AuthorizationSettings authorizationSettings)


### PR DESCRIPTION
Claims where no correctly mapped wich makes not posible to retrieve the logged user information bind to the token, now is posible to retrieve the following information bind to the ClaimTypes:

 - UserId -> Claims.NameIdentifier
 - UserName -> Claims.Name
 - Email -> Claims.Email