### PR TITLE
Removed api mandatory root key from authorization.service

### DIFF
--- a/npm/cs-authorization-connector/package.json
+++ b/npm/cs-authorization-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chustasoft/cs-authorization-connector",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "JS connector library for ChustaSoft Authorization library based on Microsoft AspNet Identity",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/npm/cs-authorization-connector/src/services/athorization.services.ts
+++ b/npm/cs-authorization-connector/src/services/athorization.services.ts
@@ -16,22 +16,22 @@ export class AuthorizationService {
 
     public async register(credentials: Credentials): Promise<Session> {
         return this.httpService.post<Credentials, Session>(
-            `${this.authorizationApiUrl}auth/register`, credentials);
+            `${this.authorizationApiUrl}/auth/register`, credentials);
     }
 
     public async login(credentials: Credentials): Promise<Session> {
         return this.httpService.post<Credentials, Session>(
-            `${this.authorizationApiUrl}auth/login`, credentials);
+            `${this.authorizationApiUrl}/auth/login`, credentials);
     }
 
     public async confirm(userValidation: UserValidation): Promise<Session> {
         return this.httpService.post<UserValidation, Session>(
-            `${this.authorizationApiUrl}auth/confirm`, userValidation);
+            `${this.authorizationApiUrl}/auth/confirm`, userValidation);
     }
 
     public async activate(userActivation: UserActivation): Promise<string> {
         return this.httpService.post<UserActivation, string>(
-            `${this.authorizationApiUrl}auth/activate`, userActivation);
+            `${this.authorizationApiUrl}/auth/activate`, userActivation);
     }
 
 }

--- a/npm/cs-authorization-connector/src/services/athorization.services.ts
+++ b/npm/cs-authorization-connector/src/services/athorization.services.ts
@@ -16,22 +16,22 @@ export class AuthorizationService {
 
     public async register(credentials: Credentials): Promise<Session> {
         return this.httpService.post<Credentials, Session>(
-            `${this.authorizationApiUrl}api/auth/register`, credentials);
+            `${this.authorizationApiUrl}auth/register`, credentials);
     }
 
     public async login(credentials: Credentials): Promise<Session> {
         return this.httpService.post<Credentials, Session>(
-            `${this.authorizationApiUrl}api/auth/login`, credentials);
+            `${this.authorizationApiUrl}auth/login`, credentials);
     }
 
     public async confirm(userValidation: UserValidation): Promise<Session> {
         return this.httpService.post<UserValidation, Session>(
-            `${this.authorizationApiUrl}api/auth/confirm`, userValidation);
+            `${this.authorizationApiUrl}auth/confirm`, userValidation);
     }
 
     public async activate(userActivation: UserActivation): Promise<string> {
         return this.httpService.post<UserActivation, string>(
-            `${this.authorizationApiUrl}api/auth/activate`, userActivation);
+            `${this.authorizationApiUrl}auth/activate`, userActivation);
     }
 
 }


### PR DESCRIPTION
Correction (#48)
- Removed api mandatory root key from authorization.service 
- Version 1.1.0 stablished in npm connector